### PR TITLE
Fix definition card

### DIFF
--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -116,8 +116,9 @@ class Buttons:
                 return e
 
         # check for definition card
-        definition_card = parent.find(".//ol/div[@class='g']/div")
+        definition_card = parent.find(".//ol/div[@class='g']/div/h3[@class='r']")
         if definition_card is not None:
+            definition_card = definition_card.getparent()
             try:
                 word_info = definition_card[0]
                 definition_info = definition_card[1]


### PR DESCRIPTION
All cards are `.g > div` so anything below this in the code (such as the
"time in" card) would have been ignored.