### PR TITLE
Translation card support

### DIFF
--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -241,7 +241,7 @@ class Buttons:
             'safe': 'on'
         }
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64)'
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36'
         }
 
         # list of URLs

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -115,6 +115,20 @@ class Buttons:
                 e.description = '%s\n%s' % (date, info)
                 return e
 
+        # Check for translation card
+        translation = node.find(".//div[@id='tw-ob']")
+        if translation is not None:
+            try:
+                source_language = translation.find(".//select[@id='tw-sl']").attrib['data-dsln']
+                target_language = translation.find(".//select[@id='tw-tl']/option[@selected='1']").text
+                translation = translation.find(".//pre[@id='tw-target-text']/span").text
+            except:
+                return None
+            else:
+                e.title = 'Translation from {} to {}'.format(source_language, target_language)
+                e.description = translation
+                return e
+
         # check for definition card
         words = parent.find(".//ol/div[@class='g']/div/h3[@class='r']/div")
         if words is not None:


### PR DESCRIPTION
The scrapped page did not have any translation card with your user agent, but did when I changed it to my browser's (chrome).
I left this change in a different commit so you can ditch/squash/leave it

Note that some searches like `translate in german Hello my name is whatever` do not return a translation card even in a browser