### PR TITLE
More cards support in `?g`

### DIFF
--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -112,6 +112,20 @@ class Buttons:
             except:
                 return None
 
+        # Check for translation card
+        translation = node.find(".//div[@id='tw-ob']")
+        if translation is not None:
+            try:
+                source_language = translation.find(".//select[@id='tw-sl']").attrib['data-dsln']
+                target_language = translation.find(".//select[@id='tw-tl']/option[@selected='1']").text
+                translation = translation.find(".//pre[@id='tw-target-text']/span").text
+            except:
+                return None
+            else:
+                e.title = 'Translation from {} to {}'.format(source_language, target_language)
+                e.description = translation
+                return e
+
         # check for definition card
         words = parent.find(".//ol/div[@class='g']/div/h3[@class='r']/div")
         if words is not None:

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -238,7 +238,7 @@ class Buttons:
             'safe': 'on'
         }
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64)'
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36'
         }
 
         # list of URLs

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -80,10 +80,16 @@ class Buttons:
         e = discord.Embed(colour=0x738bd7)
 
         # check if it's a calculator card:
-        calculator = node.find(".//span[@id='cwos']")
+        calculator = node.find(".//div[@id='cwmcwd']")
         if calculator is not None:
-            e.title = 'Calculator'
-            e.description = calculator.text
+            try:
+                formula = calculator.find(".//span[@id='cwles']").text.strip()
+                result = calculator.find(".//span[@id='cwos']").text.strip()
+            except:
+                return None
+            else:
+                e.title = 'Calculator'
+                e.description = '{} {}'.format(formula, result)
             return e
 
         # check for unit conversion card
@@ -304,7 +310,7 @@ class Buttons:
             root = etree.fromstring(await resp.text(), etree.HTMLParser())
 
             # with open('google.html', 'w', encoding='utf-8') as f:
-            #    f.write(etree.tostring(root, pretty_print=True).decode('utf-8'))
+            #     f.write(etree.tostring(root, pretty_print=True).decode('utf-8'))
 
             """
             Tree looks like this.. sort of..

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -136,7 +136,7 @@ class Buttons:
         if quick_search is not None:
             # Try to match things specific to the timeline or release date card
             timeline = quick_search.find("./div/div[@class='mod']/div[@class='_l6j']")
-            release_body = quick_search.find(".//div[@class='kp-header']/div[@class='_axe _T9h']")
+            release_body = quick_search.find(".//div[@class='kp-header']/div[@class='_axe _T9h kp-rgc']")
 
             # Check the results
             if timeline is not None:

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -179,18 +179,29 @@ class Buttons:
         if quick_search is not None:
             try:
                 title_node = quick_search.find("./div/div[@class='g']//a")
-                title = title_node.text
-                url = title_node.attrib['href']
-                summary = ''.join(quick_search.find("./div/div[@class='mod']/div[@class='_oDd']/span[@class='_Tgc']").itertext()).strip()
-                image = quick_search.find("./div/div[@class='_tN _VCh _WCh _IWg mod']//a[@class='bia uh_rl']")
-                thumbnail = parse_qs(urlparse(image.attrib['href']).query)['imgurl'][0]
+                if title_node is not None:
+                    # Let's call this the rich quick search card
+                    title = title_node.text
+                    url = title_node.attrib['href']
+                    summary = ''.join(quick_search.find("./div/div[@class='mod']/div[@class='_oDd']/span[@class='_Tgc']").itertext()).strip()
+                    image = quick_search.find("./div/div[@class='_tN _VCh _WCh _IWg mod']//a[@class='bia uh_rl']")
+                    thumbnail = parse_qs(urlparse(image.attrib['href']).query)['imgurl'][0] if image is not None else None
+                else:
+                    # And let's call this the poor quick search card
+                    title_node = quick_search.find("./div/div[@class='_tN _IWg mod']/div[@class='_f2g']")
+                    title = ' '.join(title_node.itertext()).strip()
+                    body_node = quick_search.find("./div/div[@class='kp-header']//a")
+                    summary = body_node.text
+                    url = 'https://www.google.com' + body_node.attrib['href']
+                    thumbnail = None
             except:
                 pass
             else:
                 e.title = title
                 e.url = url
                 e.description = summary
-                e.set_thumbnail(url=thumbnail)
+                if thumbnail:
+                    e.set_thumbnail(url=thumbnail)
                 return e
 
         # Parse timeline cards

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -185,7 +185,7 @@ class Buttons:
                 image = quick_search.find("./div/div[@class='_tN _VCh _WCh _IWg mod']//a[@class='bia uh_rl']")
                 thumbnail = parse_qs(urlparse(image.attrib['href']).query)['imgurl'][0]
             except:
-                return None
+                pass
             else:
                 e.title = title
                 e.url = url


### PR DESCRIPTION
The translation card needed a new user-agent to be received, and as it changed the entire DOM, the parsing of existing cards has been adjusted.
I also added the parsing of timeline cards (e.g `python release date`) and quick search (e.g `flag of nepal`)