### PR TITLE
Added PostgreSQL configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ postgresql = 'postgresql://user:password@host/database' # your postgresql info f
 challonge_api_key = '...' # for tournament cog
 ```
 
+6. **Configuration of database**
+
+To configure the PostgreSQL database for use by the bot, go to the directory where `launcher.py` is located, and run the script by doing `python3.6 launcher.py db init`
+
 ## Requirements
 
 - Python 3.6+


### PR DESCRIPTION
This step was missing from the instructions on running the bot, so I added it to make it easier for people to set up an instance of the bot.