### PR TITLE
add support for webp images to starboard

### DIFF
--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -182,7 +182,7 @@ class Stars:
 
         if message.attachments:
             file = message.attachments[0]
-            if file.url.lower().endswith(('png', 'jpeg', 'jpg', 'gif')):
+            if file.url.lower().endswith(('png', 'jpeg', 'jpg', 'gif', 'webp')):
                 embed.set_image(url=file.url)
             else:
                 embed.add_field(name='Attachment', value=f'[{file.filename}]({file.url})', inline=False)


### PR DESCRIPTION
Currently it does this
![](https://cdn.discordapp.com/attachments/252296452708106240/385248670209277952/Screen_Shot_2017-11-28_at_6.00.30_PM.png)