### PR TITLE
Replace avatar_url with avatar_url_as for mobile

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -202,7 +202,7 @@ class API:
 
     async def _member_stats(self, ctx, member, total_uses):
         e = discord.Embed(title='RTFM Stats')
-        e.set_author(name=str(member), icon_url=member.avatar_url)
+        e.set_author(name=str(member), icon_url=member.avatar_url_as(format='png'))
 
         query = 'SELECT count FROM rtfm WHERE user_id=$1;'
         record = await ctx.db.fetchrow(query, member.id)

--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -419,7 +419,7 @@ class Buttons:
         if channel is None:
             return
 
-        e.set_author(name=str(ctx.author), icon_url=ctx.author.avatar_url)
+        e.set_author(name=str(ctx.author), icon_url=ctx.author.avatar_url_as(format='png'))
         e.description = content
         e.timestamp = ctx.message.created_at
 

--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -229,7 +229,7 @@ class Meta:
         e.colour = member.colour
 
         if member.avatar:
-            e.set_thumbnail(url=member.avatar_url)
+            e.set_thumbnail(url=member.avatar_url_as(format='png'))
 
         await ctx.send(embed=e)
 

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -270,7 +270,7 @@ class Mod:
         e = discord.Embed(title=title, colour=colour)
         e.timestamp = now
         e.set_footer(text='Created')
-        e.set_author(name=str(member), icon_url=member.avatar_url)
+        e.set_author(name=str(member), icon_url=member.avatar_url_as(format='png'))
         e.add_field(name='ID', value=member.id)
         e.add_field(name='Joined', value=member.joined_at)
         e.add_field(name='Created', value=time.human_timedelta(member.created_at), inline=False)

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -145,7 +145,7 @@ class Stats:
         embed.colour = discord.Colour.blurple()
 
         owner = self.bot.get_user(self.bot.owner_id)
-        embed.set_author(name=str(owner), icon_url=owner.avatar_url)
+        embed.set_author(name=str(owner), icon_url=owner.avatar_url_as(format='png'))
 
         # statistics
         total_members = sum(1 for _ in self.bot.get_all_members())
@@ -272,7 +272,7 @@ class Stats:
         )
 
         embed = discord.Embed(title='Command Stats', colour=member.colour)
-        embed.set_author(name=str(member), icon_url=member.avatar_url)
+        embed.set_author(name=str(member), icon_url=member.avatar_url_as(format='png'))
 
         # total command uses
         query = "SELECT COUNT(*), MIN(used) FROM commands WHERE guild_id=$1 AND author_id=$2;"

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -462,7 +462,7 @@ class Tags:
 
     async def member_tag_stats(self, ctx, member):
         e = discord.Embed(colour=discord.Colour.blurple())
-        e.set_author(name=str(member), icon_url=member.avatar_url)
+        e.set_author(name=str(member), icon_url=member.avatar_url_as(format='png'))
         e.set_footer(text='These statistics are server-specific.')
 
         query = """SELECT COUNT(*)
@@ -593,7 +593,7 @@ class Tags:
         embed.set_footer(text='Alias created at')
 
         user = self.bot.get_user(owner_id) or (await self.bot.get_user_info(owner_id))
-        embed.set_author(name=str(user), icon_url=user.avatar_url)
+        embed.set_author(name=str(user), icon_url=user.avatar_url_as(format='png'))
 
         embed.add_field(name='Owner', value=f'<@{owner_id}>')
         embed.add_field(name='Original', value=record['name'])
@@ -608,7 +608,7 @@ class Tags:
         embed.set_footer(text='Tag created at')
 
         user = self.bot.get_user(owner_id) or (await self.bot.get_user_info(owner_id))
-        embed.set_author(name=str(user), icon_url=user.avatar_url)
+        embed.set_author(name=str(user), icon_url=user.avatar_url_as(format='png'))
 
         embed.add_field(name='Owner', value=f'<@{owner_id}>')
         embed.add_field(name='Uses', value=record['uses'])
@@ -701,7 +701,7 @@ class Tags:
         if rows:
             try:
                 p = Pages(ctx, entries=tuple(r[0] for r in rows))
-                p.embed.set_author(name=member.display_name, icon_url=member.avatar_url)
+                p.embed.set_author(name=member.display_name, icon_url=member.avatar_url_as(format='png'))
                 await p.paginate()
             except Exception as e:
                 await ctx.send(e)
@@ -959,7 +959,7 @@ class Tags:
         embed.set_footer(text='Tag added to box')
 
         user = self.bot.get_user(owner_id) or (await self.bot.get_user_info(owner_id))
-        embed.set_author(name=str(user), icon_url=user.avatar_url)
+        embed.set_author(name=str(user), icon_url=user.avatar_url_as(format='png'))
 
         embed.add_field(name='Owner', value=f'<@{owner_id}>')
         embed.add_field(name='Uses', value=data['uses'])
@@ -1070,7 +1070,7 @@ class Tags:
             entries = [f'{name} ({uses} uses)' for name, uses in rows]
             try:
                 p = Pages(ctx, entries=entries)
-                p.embed.set_author(name=user.display_name, icon_url=user.avatar_url)
+                p.embed.set_author(name=user.display_name, icon_url=user.avatar_url_as(format='png'))
                 p.embed.title = f'{sum(u for _, u in rows)} total uses'
                 await p.paginate()
             except Exception as e:

--- a/cogs/tournament.py
+++ b/cogs/tournament.py
@@ -1945,7 +1945,7 @@ class Tournament:
 
         info = await ctx.db.fetchrow(query, member.id)
         e = discord.Embed()
-        e.set_author(name=str(member), icon_url=member.avatar_url)
+        e.set_author(name=str(member), icon_url=member.avatar_url_as(format='png'))
 
         if record['challonge']:
             e.url = f'https://challonge.com/users/{record["challonge"]}'


### PR DESCRIPTION
This is because iOS can't display webp images, which is the default for `avatar_url`. Using `avatar_url_as(format='png')` will make the images display on iOS.