### PR TITLE
?about: only show the last three commits

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -133,7 +133,7 @@ class Stats:
     @commands.command()
     async def about(self, ctx):
         """Tells you information about the bot itself."""
-        cmd = r'git show -s HEAD~3..HEAD --format="[{}](https://github.com/Rapptz/RoboDanny/commit/%H) %s (%cr)"'
+        cmd = r'git log -n 3 -s --format="[{}](https://github.com/Rapptz/RoboDanny/commit/%H) %s (%cr)"'
         if os.name == 'posix':
             cmd = cmd.format(r'\`%h\`')
         else:


### PR DESCRIPTION
apparently HEAD~3..HEAD can sometimes show more than three commits. As a result, the embed content might be longer than 1024 characters, and therefore fail to send. This happened to me on my bot.

This commit uses a different approach to limit the output to just three commits.