### PR TITLE
add ?star jump

### DIFF
--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -719,6 +719,31 @@ class Stars:
         content, embed = self.get_emoji_message(msg, record['Stars'])
         await ctx.send(content, embed=embed)
 
+    @star.command(name='jump')
+    @requires_starboard()
+    async def star_jump(self, ctx, message: MessageID):
+        """Shows a link to a starred message via its ID.
+
+        The ID can either be the starred message ID
+        or the message ID in the starboard channel.
+        """
+
+        query = """SELECT entry.channel_id,
+                          entry.message_id
+                   FROM starrers
+                   INNER JOIN starboard_entries entry
+                   ON entry.id = starrers.entry_id
+                   WHERE entry.guild_id=$1
+                   AND (entry.message_id=$2 OR entry.bot_message_id=$2)
+                   LIMIT 1
+                """
+
+        record = await ctx.db.fetchrow(query, ctx.guild.id, message)
+        if record is None:
+            return await ctx.send('This message has not been starred.')
+
+        await ctx.send(f'https://discordapp.com/channels/{ctx.guild.id}/{record["channel_id"]}/{record["message_id"]}')
+
     @star.command(name='who')
     @requires_starboard()
     async def star_who(self, ctx, message: MessageID):


### PR DESCRIPTION
Since there are no plans to add a jump link to starboard, i implemented another way to see the context of a starred message. Simply run "?star jump \<message ID\>" and a jump link will be provided.