### PR TITLE
Monkey patch mins and secs into the units

### DIFF
--- a/cogs/utils/time.py
+++ b/cogs/utils/time.py
@@ -24,6 +24,11 @@ class ShortTime:
         now = datetime.datetime.utcnow()
         self.dt = now + relativedelta(**data)
 
+# Monkey patch mins and secs into the units
+units = pdt.pdtLocales['en_US'].units
+units['minutes'].append('mins')
+units['seconds'].append('secs')
+
 class HumanTime:
     calendar = pdt.Calendar(version=pdt.VERSION_CONTEXT_STYLE)
 


### PR DESCRIPTION
This allows the parsing of human time in formats such as `in 20 secs` or `in 5 mins`. It seems `parsedatetime` forgot about adding `mins` and `secs` in the base units.