### PR TITLE
Add alias `rw` to ?rtfm rewrite command

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -195,7 +195,7 @@ class API:
         """
         await self.do_rtfm(ctx, 'latest', obj)
 
-    @rtfm.command(name='rewrite')
+    @rtfm.command(name='rewrite',aliases=["rw"])
     async def rtfm_rewrite(self, ctx, *, obj: str = None):
         """Gives you a documentation link for a rewrite discord.py entity."""
         await self.do_rtfm(ctx, 'rewrite', obj)


### PR DESCRIPTION
This allows us to easily use the rtfm command for rewrite without having to type the entire word everytime.