### PR TITLE
improve the performance of ?random tag and ?star random

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ in the `psql` tool:
 CREATE ROLE rdanny WITH LOGIN PASSWORD 'yourpw';
 CREATE DATABASE rdanny OWNER rdanny;
 CREATE EXTENSION pg_trgm;
+CREATE EXTENSION tsm_system_rows;
 ```
 
 5. **Setup configuration**

--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -1056,15 +1056,9 @@ class Stars(commands.Cog):
 
         query = """SELECT bot_message_id
                    FROM starboard_entries
+                   TABLESAMPLE SYSTEM_ROWS(1)
                    WHERE guild_id=$1
                    AND bot_message_id IS NOT NULL
-                   OFFSET FLOOR(RANDOM() * (
-                       SELECT COUNT(*)
-                       FROM starboard_entries
-                       WHERE guild_id=$1
-                       AND bot_message_id IS NOT NULL
-                   ))
-                   LIMIT 1
                 """
 
         record = await ctx.db.fetchrow(query, ctx.guild.id)

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -166,13 +166,8 @@ class Tags(commands.Cog):
         pred = 'location_id IS NULL' if guild is None else 'location_id=$1'
         query = f"""SELECT name, content
                     FROM tags
+                    TABLESAMPLE SYSTEM_ROWS(1)
                     WHERE {pred}
-                    OFFSET FLOOR(RANDOM() * (
-                        SELECT COUNT(*)
-                        FROM tags
-                        WHERE {pred}
-                    ))
-                    LIMIT 1;
                  """
 
         if guild is None:


### PR DESCRIPTION
COUNT(*) requires a full table scan. Use the tsm_system_rows extension to efficiently select 1 row.
On my machine this resulted in a speedup of 11× for a tags table with 1 million rows and 6,388 location_ids.