### PR TITLE
Add capability to claim tag aliases based on already defined ruleset.

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -978,7 +978,10 @@ class Tags(commands.Cog):
         query = "SELECT id, owner_id FROM tags WHERE location_id=$1 AND LOWER(name)=$2;"
         row = await ctx.db.fetchrow(query, ctx.guild.id, tag.lower())
         if row is None:
-            return await ctx.send(f'A tag with the name of "{tag}" does not exist.')
+            alias_query = "SELECT tag_id, owner_id FROM tag_lookup WHERE location_id = $1 and LOWER(name) = $2;"
+            row = await ctx.db.fetchrow(alias_query, ctx.guild.id, tag.lower())
+            if row is None:
+                return await ctx.send(f'A tag with the name of "{tag}" does not exist.')
 
         member = await self.bot.get_or_fetch_member(ctx.guild, row[1])
         if member is not None:


### PR DESCRIPTION
Ability to claim tag aliases if the owner is no longer present in the server. This is to avoid 'good' alias names being lost to the void without moderator/manage messages intervention.