### PR TITLE
Export tags through ?tag all --json

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -840,8 +840,9 @@ class Tags(commands.Cog):
     @staticmethod
     def _get_tag_all_arguments(args):
         parser = Arguments(add_help=False, allow_abbrev=False)
-        parser.add_argument('--text', action='store_true')
-        parser.add_argument('--json', action='store_true')
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument('--text', action='store_true')
+        group.add_argument('--json', action='store_true')
         if args is not None:
             return parser.parse_args(shlex.split(args))
         else:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -896,7 +896,7 @@ class Tags(commands.Cog):
 
         for r in rows:
             fp = io.BytesIO(r[0].encode())
-        await ctx.send(file=discord.File(fp, 'tags.txt'))
+        await ctx.send(file=discord.File(fp, 'tags.json'))
 
     @tag.command(name='all')
     @suggest_box()


### PR DESCRIPTION
Same as `?tag all --text`, except it exports the content as JSON, with the tag's content. Closes #83. Example export:
```json
{"id":3,"name":"codeblocks","owner_id":336733686529654798,"uses":1,"can_delete":true,"is_alias":false,"content":"Use codeblocks for formatting code:\n\\`\\`\\`<language name>\n<your code here>\n\\`\\`\\`\n\nFor example:\n\\`\\`\\`python\nif True:\n    print(\"Hi!\")\n\\`\\`\\`\nProduces:\n```python\nif True:\n    print(\"Hi!\")\n```"}
```