### PR TITLE
Fix Bothealth command.

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -693,7 +693,7 @@ class Stats(commands.Cog):
             total_warnings += 1
 
         try:
-            task_retriever = asyncio.Task.all_tasks
+            task_retriever = asyncio.all_tasks
         except AttributeError:
             # future proofing for 3.9 I guess
             task_retriever = asyncio.all_tasks


### PR DESCRIPTION
Fixes the bothealth command since Task is depricated. 

Asyncio documentation:
      .. deprecated-removed:: 3.7 3.9

         Do not call this as a task method. Use the :func:`asyncio.all_tasks`
         function instead.