### PR TITLE
Added `?rtfm master ...` subcommand for ease of access during dpy 2.0 development.

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -328,12 +328,12 @@ class API(commands.Cog):
         """Gives you a documentation link for a Python entity (Japanese)."""
         await self.do_rtfm(ctx, 'python-jp', obj)
 
-    @rtfm.command(name="master", aliases=["2.0"])
+    @rtfm.command(name='master', aliases=['2.0'])
     async def rtfm_master(self, ctx, *, obj: str = None):
         """Gives you a documentation link for a discord.py entity (master branch)"""
         await self.do_rtfm(ctx, 'master', obj)
 
-    @rtfm.command(name="master-jp", aliases=["2.0-jp"])
+    @rtfm.command(name='master-jp', aliases=['2.0-jp'])
     async def rtfm_master_jp(self, ctx, *, obj: str = None):
         """Gives you a documentation link for a discord.py entity (master branch)"""
         await self.do_rtfm(ctx, 'master-jp', obj)

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -252,7 +252,7 @@ class API(commands.Cog):
             'python': 'https://docs.python.org/3',
             'python-jp': 'https://docs.python.org/ja/3',
             'master': 'https://discordpy.readthedocs.io/en/master',
-            'master-jp': 'https://discordpy.readthedocs.io/jp/master'
+            'master-jp': 'https://discordpy.readthedocs.io/ja/master'
         }
 
         if obj is None:

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -251,6 +251,8 @@ class API(commands.Cog):
             'latest-jp': 'https://discordpy.readthedocs.io/ja/latest',
             'python': 'https://docs.python.org/3',
             'python-jp': 'https://docs.python.org/ja/3',
+            'master': 'https://discordpy.readthedocs.io/en/master',
+            'master-jp': 'https://discordpy.readthedocs.io/jp/master'
         }
 
         if obj is None:
@@ -325,6 +327,16 @@ class API(commands.Cog):
     async def rtfm_python_jp(self, ctx, *, obj: str = None):
         """Gives you a documentation link for a Python entity (Japanese)."""
         await self.do_rtfm(ctx, 'python-jp', obj)
+
+    @rtfm.command(name="master", aliases=["2.0"])
+    async def rtfm_master(self, ctx, *, obj: str = None):
+        """Gives you a documentation link for a discord.py entity (master branch)"""
+        await self.do_rtfm(ctx, 'master', obj)
+
+    @rtfm.command(name="master-jp", aliases=["2.0-jp"])
+    async def rtfm_master_jp(self, ctx, *, obj: str = None):
+        """Gives you a documentation link for a discord.py entity (master branch)"""
+        await self.do_rtfm(ctx, 'master-jp', obj)
 
     async def _member_stats(self, ctx, member, total_uses):
         e = discord.Embed(title='RTFM Stats')


### PR DESCRIPTION
Following the current spec, I have added the EN and JP version of the `master` branch target to RDanny's `rtfm` command as a subcommand.