### PR TITLE
Fix typos when unmuting members

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1508,7 +1508,7 @@ class Mod(commands.Cog):
         role = discord.Object(id=ctx.guild_config.mute_role_id)
         total = len(members)
         if total == 0:
-            return await ctx.send('Missing members to mute.')
+            return await ctx.send('Missing members to unmute.')
 
         failed = 0
         for member in members:


### PR DESCRIPTION
Replacing "mute" by "unmute"