### PR TITLE
fix invalid url check for vreddit

### DIFF
--- a/cogs/buttons.py
+++ b/cogs/buttons.py
@@ -88,7 +88,7 @@ class RedditMediaURL:
             async with ctx.session.get(url, headers=headers) as resp:
                 url = resp.url
 
-        is_valid_path = url.host.endswith('.reddit.com') and cls.VALID_PATH.match(url.path)
+        is_valid_path = url.host and url.host.endswith('.reddit.com') and cls.VALID_PATH.match(url.path)
         if not is_valid_path:
             raise commands.BadArgument('Not a reddit URL.')
 


### PR DESCRIPTION
The converter is supposed to raise BadArgument for cases like "?vreddit whatever" but instead triggers typing and does nothing. Since, url.host is None in such cases and vreddit's error handler eats up AttributeError caused by the NoneType.