### PR TITLE
add nitro 4000 char check to tag create

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -339,6 +339,9 @@ class Tags(commands.Cog):
         if self.is_tag_being_made(ctx.guild.id, name):
             return await ctx.send('This tag is currently being made by someone.')
 
+        if len(content) > 2000:
+            return await ctx.send('Tag content is a maximum of 2000 characters.')
+
         await self.create_tag(ctx, name, content)
 
     @tag.command()

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -452,6 +452,9 @@ class Tags(commands.Cog):
         if msg.attachments:
             clean_content = f'{clean_content}\n{msg.attachments[0].url}'
 
+        if len(content) > 2000:
+            return await ctx.send('Tag content is a maximum of 2000 characters.')
+
         try:
             await self.create_tag(ctx, name, clean_content)
         finally:


### PR DESCRIPTION
Bots can't send 4000 characters but users can, so creating a tag that's over 2000 characters long will make the bot silently fail when the tag is shown.