### PR TITLE
Fix a minor grammar error

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -71,7 +71,7 @@ class DisambiguateMember(commands.IDConverter):
                 raise commands.BadArgument(f'Could not find this member. {e}') from None
 
         if result is None:
-            raise commands.BadArgument("Could not found this member. Note this is case sensitive.")
+            raise commands.BadArgument("Could not find this member. Note this is case sensitive.")
         return result
 
 def valid_nnid(argument):


### PR DESCRIPTION
There is a minor grammar error in `DisambiguateMember`. Should be "find" instead of "found".