### PR TITLE
Remove useless function, `transform`

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -279,9 +279,6 @@ class API(commands.Cog):
                     break
 
         cache = list(self._rtfm_cache[key].items())
-        def transform(tup):
-            return tup[0]
-
         matches = fuzzy.finder(obj, cache, key=lambda t: t[0], lazy=False)[:8]
 
         e = discord.Embed(colour=discord.Colour.blurple())


### PR DESCRIPTION
There was a useless function called `transform` in `build_rtfm_lookup_table`