### PR TITLE
Add "m" alias to rtfm master

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -331,7 +331,7 @@ class API(commands.Cog):
         """Gives you a documentation link for a Python entity (Japanese)."""
         await self.do_rtfm(ctx, 'python-jp', obj)
 
-    @rtfm.command(name='master', aliases=['2.0'])
+    @rtfm.command(name='master', aliases=['2.0', 'm'])
     async def rtfm_master(self, ctx, *, obj: str = None):
         """Gives you a documentation link for a discord.py entity (master branch)"""
         await self.do_rtfm(ctx, 'master', obj)


### PR DESCRIPTION
Add simplicity to the rtfm command where instead of typing `!rtfm master` or `!rtfm 2.0` we can simply type `!rtfm m <object>`.