### PR TITLE
Use commands.Author as default for tags commands

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -860,7 +860,7 @@ class Tags(commands.Cog):
 
     @tag.command(name='list')
     @suggest_box()
-    async def _list(self, ctx: GuildContext, *, member: discord.User = commands.param(default=lambda ctx: ctx.author)):
+    async def _list(self, ctx: GuildContext, *, member: discord.User = commands.Author):
         """Lists all the tags that belong to you or someone else."""
 
         query = """SELECT name, id
@@ -881,7 +881,7 @@ class Tags(commands.Cog):
 
     @commands.command()
     @suggest_box()
-    async def tags(self, ctx: GuildContext, *, member: discord.User = commands.param(default=lambda ctx: ctx.author)):
+    async def tags(self, ctx: GuildContext, *, member: discord.User = commands.Author):
         """An alias for tag list command."""
         await ctx.invoke(self._list, member=member)
 
@@ -1287,7 +1287,7 @@ class Tags(commands.Cog):
         await ctx.send(embed=embed)
 
     @box.command(name='list')
-    async def box_list(self, ctx: Context, *, user: discord.User = commands.param(default=lambda ctx: ctx.author)):
+    async def box_list(self, ctx: Context, *, user: discord.User = commands.Author):
         """Lists all the tags in the box that belong to you or someone else.
 
         Unlike the regular tag list command, this one is sorted by uses.


### PR DESCRIPTION
This pull request changes some tags commands to use `commands.Author` as default instead of manually setting a default via `commands.param()` as it caused the command signature to look ugly. While this could be fixed by passing a `displayed_default` to `param()` but using `commands.Author` is more cleaner, I guess.