### PR TITLE
Small charinfo redesign

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -305,7 +305,7 @@ class Meta(commands.Cog):
         def to_string(c):
             digit = f'{ord(c):x}'
             name = unicodedata.name(c, 'Name not found.')
-            return f'`\\U{digit:>08}`: {name} - {c} \N{EM DASH} <http://www.fileformat.info/info/unicode/char/{digit}>'
+            return f'[`\\U{digit:>08}`](<http://www.fileformat.info/info/unicode/char/{digit}>): {name} **\N{EM DASH}** {c}'
 
         msg = '\n'.join(map(to_string, characters))
         if len(msg) > 2000:


### PR DESCRIPTION
Very small PR, this just makes `?charinfo` easier to visualize by moving the `fileformat.info` links into a markdown hyperlink

Here's a before and after image:
![image](https://github.com/Rapptz/RoboDanny/assets/82718618/6029486c-577d-46ef-bc3a-9d52ada46020)
