### PR TITLE
small fix to not revive theads in the timeout response

### DIFF
--- a/cogs/dpy.py
+++ b/cogs/dpy.py
@@ -540,7 +540,8 @@ class DPYExclusive(commands.Cog, name='discord.py'):
                 )
                 await self.mark_as_solved(ctx.channel, ctx.channel.owner or ctx.author)
             elif confirm is None:
-                await ctx.send('Timed out waiting for a response. Not marking as solved.')
+                if not ctx.channel.locked:
+                    await ctx.send('Timed out waiting for a response. Not marking as solved.')
             else:
                 await ctx.send('Not marking as solved.')
 


### PR DESCRIPTION
if someone runs `?solved` in discord.py guild and a prompt is up already, once it times out it'll reopen the thread. this is a quick fix for this