### PR TITLE
Fix tempblock storing the wrong ID

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -573,7 +573,7 @@ class API(commands.Cog):
             'tempblock',
             ctx.guild.id,
             ctx.author.id,
-            ctx.channel.id,
+            channel.id,
             member.id,
             created=created_at,
             timezone=zone or 'UTC',


### PR DESCRIPTION
Makes `?tempblock` store the channel from `get_block_channel` rather than `ctx.channel`.

Currently L607 fails because a thread ID is stored for d.py tempblocks executed within the help thread.