### PR TITLE
Correct padding in user_id base64 decoding

### DIFF
--- a/cogs/dpy.py
+++ b/cogs/dpy.py
@@ -40,7 +40,7 @@ def validate_token(token: str) -> bool:
     try:
         # Just check if the first part validates as a user ID
         (user_id, _, _) = token.split('.')
-        user_id = int(base64.b64decode(user_id + '==', validate=True))
+        user_id = int(base64.b64decode(user_id + '=' * (len(user_id) % 4), validate=True))
     except (ValueError, binascii.Error):
         return False
     else:


### PR DESCRIPTION
A [change in Python 3.11](https://docs.python.org/3/library/binascii.html#binascii.a2b_base64) will cause this function to error often due to being incorrectly padded, as such we now calculate the necessary padding for each user_id before attempting to decode it.

I verified this on Python 3.8 and Python 3.12 and confirm it works okay on my end.