### PR TITLE
Implement Message context menu & command for discord.py's "No General" role usage.

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -60,7 +60,7 @@ def is_discord_py_helper(member: discord.Member) -> bool:
 
 def can_use_no_general(member: discord.Member) -> bool:
     # Using `ban_members` over `manage_roles` since Documentation Manager has that
-    return member.guild_permissions.ban_members or member._roles.has(DISCORD_PY_HELPER_ROLE)
+    return member.guild_permissions.ban_members or is_discord_py_helper(member)
 
 
 def can_use_block():

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -175,7 +175,7 @@ class BotUser(commands.Converter):
 
 
 class CreateHelpThreadModal(discord.ui.Modal, title='Create help thread'):
-    thread_name = discord.ui.TextInput(label='Thread title', placeholder='Name for the help thread...', min_length=15, max_length=100)
+    thread_name = discord.ui.TextInput(label='Thread title', placeholder='Name for the help thread...', min_length=20, max_length=100)
     should_mute = discord.ui.TextInput(label='Apply mute?', default="Yes", min_length=2, max_length=3)
 
     def __init__(self) -> None:

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -181,6 +181,9 @@ class CreateHelpThreadModal(discord.ui.Modal, title='Create help thread'):
     def __init__(self) -> None:
         super().__init__(custom_id='dpy-create-thread-modal')
 
+    async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
+        await interaction.response.send_message(f'Sorry, something went wrong.\n\n{error}', ephemeral=True)
+
     async def on_submit(self, interaction: discord.Interaction) -> None:
         self.stop()
         await interaction.response.send_message('Thread created now.', ephemeral=True)

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -176,6 +176,7 @@ class BotUser(commands.Converter):
 
 class CreateHelpThreadModal(discord.ui.Modal, title='Create help thread'):
     thread_name = discord.ui.TextInput(label='Thread title', placeholder='Name for the help thread...', min_length=15, max_length=100)
+    should_mute = discord.ui.TextInput(label='Apply mute?', default="Yes", min_length=2, max_length=3)
 
     def __init__(self) -> None:
         super().__init__(custom_id='dpy-create-thread-modal')
@@ -287,7 +288,8 @@ class API(commands.Cog):
         )
         await thread.send(f'This thread was created on behalf of {message.author.mention}. Please continue your discussion for help in here.')
 
-        await self._attempt_general_block(interaction.user, message.author)  # type: ignore # we know it's a member here due to aforemention guild guard
+        if modal.should_mute.value.lower() == "yes":
+            await self._attempt_general_block(interaction.user, message.author)  # type: ignore # we know it's a member here due to aforemention guild guard
 
     def parse_object_inv(self, stream: SphinxObjectFileReader, url: str) -> dict[str, str]:
         # key: URL

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -180,6 +180,9 @@ class CreateHelpThreadModal(discord.ui.Modal, title='Create help thread'):
     def __init__(self) -> None:
         super().__init__(custom_id='dpy-create-thread-modal')
 
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self.stop()
+
 
 class RepositoryExample(NamedTuple):
     path: str

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -285,7 +285,7 @@ class API(commands.Cog):
             content=message.content,
             files=[await attachment.to_file() for attachment in message.attachments]
         )
-        await thread.send(f'This thread was created on behalf of {message.author}. Please continue your discussion for help in here.')
+        await thread.send(f'This thread was created on behalf of {message.author.mention}. Please continue your discussion for help in here.')
 
         await self._attempt_general_block(interaction.user, message.author)  # type: ignore # we know it's a member here due to aforemention guild guard
 

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -218,7 +218,7 @@ class API(commands.Cog):
             role = discord.Object(id=USER_BOTS_ROLE)
             await member.add_roles(role)
 
-    async def cog_unload(self) -> None:
+    def cog_unload(self) -> None:
         self.bot.tree.remove_command(
             self.create_thread_context.name,
             guild=discord.Object(id=DISCORD_PY_GUILD),

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -174,11 +174,11 @@ class BotUser(commands.Converter):
             return user
 
 
-class CreateHelpThreadModal(discord.ui.Modal, title="Create help thread"):
-    thread_name = discord.ui.TextInput(label="Thread title", placeholder="Name for the help thread...", min_length=15, max_length=100)
+class CreateHelpThreadModal(discord.ui.Modal, title='Create help thread'):
+    thread_name = discord.ui.TextInput(label='Thread title', placeholder='Name for the help thread...', min_length=15, max_length=100)
 
     def __init__(self) -> None:
-        super().__init__(custom_id="dpy-create-thread-modal")
+        super().__init__(custom_id='dpy-create-thread-modal')
 
 
 class RepositoryExample(NamedTuple):
@@ -199,7 +199,7 @@ class API(commands.Cog):
     def __init__(self, bot: RoboDanny):
         self.bot: RoboDanny = bot
         self.issue = re.compile(r'##(?P<number>[0-9]+)')
-        self.create_thread_context = discord.app_commands.ContextMenu(name="Create help thread", callback=self.create_thread_callback)
+        self.create_thread_context = discord.app_commands.ContextMenu(name='Create help thread', callback=self.create_thread_callback)
         self.bot.tree.add_command(self.create_thread_context, guild=discord.Object(id=DISCORD_PY_GUILD))
 
     @property
@@ -227,12 +227,12 @@ class API(commands.Cog):
         if not reminder:
             return # we can't apply the timed role.
 
-        await member.add_roles(discord.Object(id=DISCORD_PY_NO_GENERAL_ROLE), reason="Rule 16 - requesting help in general.")
+        await member.add_roles(discord.Object(id=DISCORD_PY_NO_GENERAL_ROLE), reason='Rule 16 - requesting help in general.')
 
         now = discord.utils.utcnow()
         await reminder.create_timer(
             now + datetime.timedelta(hours=1),
-            "general_block",
+            'general_block',
             moderator.id,
             member.id,
             created=now

--- a/cogs/api.py
+++ b/cogs/api.py
@@ -58,9 +58,9 @@ def is_discord_py_helper(member: discord.Member) -> bool:
 
     return member._roles.has(DISCORD_PY_HELPER_ROLE)
 
-def can_use_no_general(interaction: discord.Interaction) -> bool:
+def can_use_no_general(member: discord.Member) -> bool:
     # Using `ban_members` over `manage_roles` since Documentation Manager has that
-    return interaction.user.guild_permissions.ban_members or interaction.user.get_role(DISCORD_PY_HELPER_ROLE)  # type: ignore # interaction.user is a Member
+    return member.guild_permissions.ban_members or member._roles.has(DISCORD_PY_HELPER_ROLE)
 
 
 def can_use_block():
@@ -267,6 +267,9 @@ class API(commands.Cog):
 
 
     async def create_thread_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
+        if not can_use_no_general(interaction.user):  # type: ignore # discord.Member since we're guild guarded
+            return await interaction.response.send_message('Sorry, this command is not available to you!')
+
         modal = CreateHelpThreadModal()
         await interaction.response.send_modal(modal)
         _waited = await modal.wait()


### PR DESCRIPTION
As discussed by the moderation team, I have implemented the necessary machinery to achieve the following flow:

Context Menu on user message -> Prompt mod/helper for thread title -> create help forum thread based on input and message content and optionally apply a timed "No General" role on the target author (default is to do so).

The prefix command works the exact same as `?tempblock` and no "permanent" variant exists.

This is currently open to moderators and discord.py helpers, but easily changed if needed.

I have done my best to replicate the discord.py server infrastructure involved in this PR, as well as the relevant RDanny mechanisms involved and all seem to work a-ok now:-
![DiscordCanary_H9qqhohQlx](https://github.com/user-attachments/assets/c8cb6281-55d2-40ef-b95c-c78feb675203)
![DiscordCanary_ZVoOth7TOR](https://github.com/user-attachments/assets/d526a8bf-b039-4c2a-9f5e-303380ad73e9)
