### PR TITLE
Account for aliases in ?config enable/disable

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -55,18 +55,12 @@ else:
         async def convert(self, ctx: Context, argument: str) -> str:
             lowered = argument.lower()
 
-            # fmt: off
-            valid_commands = {
-                c.qualified_name
-                for c in ctx.bot.walk_commands()
-                if c.cog_name not in ('Config', 'Admin')
-            }
-            # fmt: on
+            command = ctx.bot.get_command(lowered)
 
-            if lowered not in valid_commands:
+            if command is None or command.cog_name in ('Config', 'Admin'):
                 raise commands.BadArgument(f'Command {lowered!r} is not valid.')
 
-            return lowered
+            return command.qualified_name
 
 
 class ResolvedCommandPermissions:


### PR DESCRIPTION
This PR changes the `CommandName` converter to use `Bot.get_command()` which accounts for aliases instead of just the qualified name. The converter still returns the true qualified name of the found command instead of the entered alias.